### PR TITLE
Add categoria admin feature

### DIFF
--- a/src/app/admin/admin-home.component.ts
+++ b/src/app/admin/admin-home.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-admin-home',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h1>Administrador</h1>
+    <p>Seleccione una opción del menú.</p>
+  `,
+  styles: []
+})
+export class AdminHomeComponent {}

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-admin',
   standalone: true,
+  imports: [RouterModule],
   template: `
     <div class="row">
       <div class="col-md-3 mb-4">
@@ -10,11 +12,11 @@ import { Component } from '@angular/core';
           <a href="#" class="list-group-item list-group-item-action">Gestionar Productos</a>
           <a href="#" class="list-group-item list-group-item-action">Ver Ventas</a>
           <a href="#" class="list-group-item list-group-item-action">Configuraci\u00f3n</a>
+          <a routerLink="categoria" class="list-group-item list-group-item-action">Categoria</a>
         </div>
       </div>
       <div class="col">
-        <h1>Administrador</h1>
-        <p>Seleccione una opci\u00f3n del men\u00fa.</p>
+        <router-outlet></router-outlet>
       </div>
     </div>
   `,

--- a/src/app/admin/categoria-list.component.ts
+++ b/src/app/admin/categoria-list.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CategoriaService } from '../services/categoria.service';
+import { Categoria } from '../models/categoria.model';
+
+@Component({
+  selector: 'app-categoria-list',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Categorías</h2>
+    <table class="table table-bordered" *ngIf="categorias.length">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nombre</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let c of categorias">
+          <td>{{ c.id }}</td>
+          <td>{{ c.nombre }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p *ngIf="!categorias.length">No hay categorias.</p>
+  `,
+  styles: []
+})
+export class CategoriaListComponent implements OnInit {
+  categorias: Categoria[] = [];
+
+  constructor(private categoriaService: CategoriaService) {}
+
+  ngOnInit(): void {
+    this.categoriaService.getCategorias().subscribe(data => this.categorias = data);
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,17 @@
 import { Routes } from '@angular/router';
 import { CatalogComponent } from './catalog/catalog.component';
 import { AdminComponent } from './admin/admin.component';
+import { CategoriaListComponent } from './admin/categoria-list.component';
+import { AdminHomeComponent } from './admin/admin-home.component';
 
 export const appRoutes: Routes = [
   { path: '', component: CatalogComponent },
-  { path: 'admin', component: AdminComponent }
+  {
+    path: 'admin',
+    component: AdminComponent,
+    children: [
+      { path: '', component: AdminHomeComponent },
+      { path: 'categoria', component: CategoriaListComponent }
+    ]
+  }
 ];

--- a/src/app/models/categoria.model.ts
+++ b/src/app/models/categoria.model.ts
@@ -1,0 +1,5 @@
+export interface Categoria {
+  id: number;
+  nombre: string;
+  parent?: Categoria;
+}

--- a/src/app/services/categoria.service.ts
+++ b/src/app/services/categoria.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { Categoria } from '../models/categoria.model';
+
+@Injectable({ providedIn: 'root' })
+export class CategoriaService {
+  private baseUrl = environment.apiBaseUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getCategorias(): Observable<Categoria[]> {
+    return this.http.get<Categoria[]>(`${this.baseUrl}/categorias`);
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiBaseUrl: 'http://localhost:8080'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: false
+  production: false,
+  apiBaseUrl: 'http://localhost:8080'
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 import { AppComponent } from './app/app.component';
 import { appRoutes } from './app/app.routes';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes)]
+  providers: [provideRouter(appRoutes), provideHttpClient()]
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- add API base URL in environment files
- create categoria models and service
- display list of categorias under admin section
- add admin home component with nested routing
- register HttpClient provider

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c1b7775c832f907d7682dbf0ef34