### PR TITLE
feat: add path property to picture models

### DIFF
--- a/src/app/admin/producto-form.component.ts
+++ b/src/app/admin/producto-form.component.ts
@@ -171,6 +171,7 @@ export class ProductoFormComponent implements OnInit {
           this.pictures =
             p.pictureGallery?.pictures.map((pic) => ({
               url: pic.url,
+              path: pic.path,
               fileName: pic.fileName,
               mimeType: pic.mimeType,
               size: pic.size,
@@ -260,7 +261,7 @@ export class ProductoFormComponent implements OnInit {
           cover: false
         };
         if (idx === 0) {
-          this.pictures[i] = { ...this.pictures[i], ...picData };
+          this.pictures[i] = { ...this.pictures[i], ...picData, path: undefined };
         } else {
           this.pictures.splice(i + idx, 0, picData);
         }

--- a/src/app/models/picture.model.ts
+++ b/src/app/models/picture.model.ts
@@ -1,6 +1,7 @@
 export interface Picture {
   id: number;
   url: string;
+  path: string;
   fileName: string;
   mimeType: string;
   size: number;
@@ -11,6 +12,7 @@ export interface Picture {
 
 export interface PictureRequest {
   url: string;
+  path?: string;
   fileName: string;
   mimeType: string;
   size: number;


### PR DESCRIPTION
## Summary
- add required `path` to `Picture` and optional `path` to `PictureRequest`
- handle picture `path` in product form when editing or replacing images

## Testing
- `npm test` *(fails: Workspace extension with invalid name (defaultProject) found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fd6330e1c832fbdacc30ad17adea4