### PR TITLE
refactor: send pictures as file uploads

### DIFF
--- a/src/app/models/picture.model.ts
+++ b/src/app/models/picture.model.ts
@@ -9,13 +9,3 @@ export interface Picture {
   cover: boolean;
   createdDate: string;
 }
-
-export interface PictureRequest {
-  url: string;
-  path?: string;
-  fileName: string;
-  mimeType: string;
-  size: number;
-  order?: number;
-  cover: boolean;
-}

--- a/src/app/services/picture.service.ts
+++ b/src/app/services/picture.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { Picture, PictureRequest } from '../models/picture.model';
+import { Picture } from '../models/picture.model';
 
 @Injectable({ providedIn: 'root' })
 export class PictureService {
@@ -22,15 +22,42 @@ export class PictureService {
       .pipe(map((resp) => resp.data));
   }
 
-  createPicture(req: PictureRequest): Observable<Picture> {
+  createPicture(file: File, order?: number, cover?: boolean): Observable<Picture> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    let params = new HttpParams();
+    if (order !== undefined) {
+      params = params.set('order', order.toString());
+    }
+    if (cover !== undefined) {
+      params = params.set('cover', cover.toString());
+    }
+
     return this.http
-      .post<{ data: Picture }>(`${this.baseUrl}/pictures`, req)
+      .post<{ data: Picture }>(`${this.baseUrl}/pictures`, formData, { params })
       .pipe(map((resp) => resp.data));
   }
 
-  updatePicture(id: number, req: PictureRequest): Observable<Picture> {
+  updatePicture(
+    id: number,
+    file: File,
+    order?: number,
+    cover?: boolean
+  ): Observable<Picture> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    let params = new HttpParams();
+    if (order !== undefined) {
+      params = params.set('order', order.toString());
+    }
+    if (cover !== undefined) {
+      params = params.set('cover', cover.toString());
+    }
+
     return this.http
-      .put<{ data: Picture }>(`${this.baseUrl}/pictures/${id}`, req)
+      .put<{ data: Picture }>(`${this.baseUrl}/pictures/${id}`, formData, { params })
       .pipe(map((resp) => resp.data));
   }
 


### PR DESCRIPTION
## Summary
- send picture files using FormData and optional order/cover query params
- update product form to handle file objects and call new picture upload API
- drop obsolete PictureRequest model

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fd7f5eaf8832f907c42394a9d0e3c