### PR TITLE
Fetch picture blobs for product form

### DIFF
--- a/src/app/services/picture.service.ts
+++ b/src/app/services/picture.service.ts
@@ -22,6 +22,12 @@ export class PictureService {
       .pipe(map((resp) => resp.data));
   }
 
+  getPictureFile(id: number): Observable<Blob> {
+    return this.http.get(`${this.baseUrl}/pictures/${id}/file`, {
+      responseType: 'blob'
+    });
+  }
+
   createPicture(file: File, order?: number, cover?: boolean): Observable<Picture> {
     const formData = new FormData();
     formData.append('file', file);


### PR DESCRIPTION
## Summary
- add `getPictureFile` to picture service for retrieving image blobs
- load gallery pictures as object URLs in product form for editing

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fe037273c832f8a88d742dbcaac4b