### PR TITLE
Make file optional in picture update and adjust product form

### DIFF
--- a/src/app/services/picture.service.ts
+++ b/src/app/services/picture.service.ts
@@ -47,12 +47,14 @@ export class PictureService {
 
   updatePicture(
     id: number,
-    file: File,
+    file?: File,
     order?: number,
     cover?: boolean
   ): Observable<Picture> {
     const formData = new FormData();
-    formData.append('file', file);
+    if (file) {
+      formData.append('file', file);
+    }
 
     let params = new HttpParams();
     if (order !== undefined) {


### PR DESCRIPTION
## Summary
- allow PictureService.updatePicture to accept optional file and only append when present
- update ProductoFormComponent to update existing pictures and pass undefined file when only order or cover change

## Testing
- `npm test -- --watch=false` *(fails: Workspace extension with invalid name (defaultProject); Unknown argument: watch)*

------
https://chatgpt.com/codex/tasks/task_e_68915293a900832f8bebd183545d0e57