### PR TITLE
Add CatalogoAtributo CRUD components

### DIFF
--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -15,6 +15,9 @@ import { RouterModule } from '@angular/router';
           <li class="nav-item">
             <a routerLink="producto" class="nav-link">Producto</a>
           </li>
+          <li class="nav-item">
+            <a routerLink="catalogo-atributo" class="nav-link">Catálogo Atributo</a>
+          </li>
         </ul>
       </nav>
       <div class="flex-grow-1 p-3">

--- a/src/app/admin/catalogo-atributo-form.component.ts
+++ b/src/app/admin/catalogo-atributo-form.component.ts
@@ -1,0 +1,133 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { CatalogoAtributoService } from '../services/catalogo-atributo.service';
+import { CatalogoAtributoRequest } from '../models/catalogo-atributo.model';
+
+@Component({
+  selector: 'app-catalogo-atributo-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  template: `
+    <h2>{{ isEdit ? 'Editar Atributo' : 'Nuevo Atributo' }}</h2>
+    <form (ngSubmit)="submit()" *ngIf="atributo">
+      <div class="has-danger mb-3">
+        <label class="form-label" for="nombre">Nombre</label>
+        <input
+          id="nombre"
+          class="form-control"
+          [ngClass]="{ 'is-invalid': errorMessages.nombre }"
+          [(ngModel)]="atributo.nombre"
+          name="nombre"
+        />
+        <div class="invalid-feedback" *ngIf="errorMessages.nombre">
+          {{ errorMessages.nombre }}
+        </div>
+      </div>
+      <div class="has-danger mb-3">
+        <label class="form-label" for="dataType">Tipo de Dato</label>
+        <select
+          id="dataType"
+          class="form-select"
+          [ngClass]="{ 'is-invalid': errorMessages.dataType }"
+          [(ngModel)]="atributo.dataType"
+          name="dataType"
+        >
+          <option value="TEXT">TEXT</option>
+          <option value="NUMERIC">NUMERIC</option>
+          <option value="BOOLEAN">BOOLEAN</option>
+          <option value="DATE">DATE</option>
+        </select>
+        <div class="invalid-feedback" *ngIf="errorMessages.dataType">
+          {{ errorMessages.dataType }}
+        </div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="unidad">Unidad</label>
+        <input id="unidad" class="form-control" [(ngModel)]="atributo.unidad" name="unidad" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="descripcion">Descripción</label>
+        <input id="descripcion" class="form-control" [(ngModel)]="atributo.descripcion" name="descripcion" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="orden">Orden</label>
+        <input id="orden" type="number" class="form-control" [(ngModel)]="atributo.orden" name="orden" />
+      </div>
+      <div class="mb-3 form-check">
+        <input id="activo" type="checkbox" class="form-check-input" [(ngModel)]="atributo.activo" name="activo" />
+        <label class="form-check-label" for="activo">Activo</label>
+      </div>
+      <div class="mb-3 form-check">
+        <input id="validRange" type="checkbox" class="form-check-input" [(ngModel)]="atributo.validRange" name="validRange" />
+        <label class="form-check-label" for="validRange">Validar rango</label>
+      </div>
+      <div class="mb-3" *ngIf="atributo.validRange">
+        <label class="form-label" for="valorMin">Valor Mínimo</label>
+        <input id="valorMin" type="number" class="form-control" [(ngModel)]="atributo.valorMin" name="valorMin" />
+        <label class="form-label mt-2" for="valorMax">Valor Máximo</label>
+        <input id="valorMax" type="number" class="form-control" [(ngModel)]="atributo.valorMax" name="valorMax" />
+      </div>
+      <button class="btn btn-primary" type="submit">Guardar</button>
+      <button class="btn btn-secondary ms-2" type="button" (click)="volver()">Cancelar</button>
+    </form>
+  `,
+  styles: []
+})
+export class CatalogoAtributoFormComponent implements OnInit {
+  atributo: CatalogoAtributoRequest = { nombre: '', dataType: 'TEXT', activo: true };
+  isEdit = false;
+  errorMessages: Record<string, string> = {};
+
+  constructor(
+    private service: CatalogoAtributoService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      this.isEdit = true;
+      const id = Number(idParam);
+      this.service.getCatalogoAtributo(id).subscribe((a) => {
+        this.atributo = {
+          nombre: a.nombre,
+          dataType: a.dataType,
+          unidad: a.unidad,
+          descripcion: a.descripcion,
+          orden: a.orden,
+          valorMin: a.valorMin,
+          valorMax: a.valorMax,
+          activo: a.activo,
+          validRange: a.valorMin !== undefined || a.valorMax !== undefined
+        };
+      });
+    }
+  }
+
+  submit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    this.errorMessages = {};
+    const obs = this.isEdit && idParam
+      ? this.service.updateCatalogoAtributo(Number(idParam), this.atributo)
+      : this.service.createCatalogoAtributo(this.atributo);
+    obs.subscribe({
+      next: () => this.volver(),
+      error: (err) => this.handleErrors(err)
+    });
+  }
+
+  volver(): void {
+    this.router.navigate(['../'], { relativeTo: this.route });
+  }
+
+  private handleErrors(err: any): void {
+    if (err.error && Array.isArray(err.error.errors)) {
+      for (const e of err.error.errors) {
+        this.errorMessages[e.field] = e.message;
+      }
+    }
+  }
+}

--- a/src/app/admin/catalogo-atributo-list.component.ts
+++ b/src/app/admin/catalogo-atributo-list.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router, ActivatedRoute } from '@angular/router';
+import { CatalogoAtributoService } from '../services/catalogo-atributo.service';
+import { CatalogoAtributo } from '../models/catalogo-atributo.model';
+
+@Component({
+  selector: 'app-catalogo-atributo-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  template: `
+    <div class="card border-secondary mb-3">
+      <h3 class="card-header">Catálogo de Atributos</h3>
+      <div class="card-body">
+        <div class="mb-3 text-end">
+          <a routerLink="nuevo" class="btn btn-success">Nuevo Atributo</a>
+        </div>
+
+        <table class="table table-hover" *ngIf="atributos.length">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Nombre</th>
+              <th scope="col">Tipo</th>
+              <th scope="col">Activo</th>
+              <th scope="col">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let a of atributos">
+              <th scope="row">{{ a.id }}</th>
+              <td>{{ a.nombre }}</td>
+              <td>{{ a.dataType }}</td>
+              <td>{{ a.activo ? 'Sí' : 'No' }}</td>
+              <td>
+                <button type="button" class="btn btn-primary me-2" (click)="editAtributo(a.id)">Editar</button>
+                <button type="button" class="btn btn-danger" (click)="confirmDelete(a.id)">Eliminar</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p *ngIf="!atributos.length">No hay atributos.</p>
+      </div>
+    </div>
+
+    <div class="modal show d-block" tabindex="-1" *ngIf="deleteId !== null">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Confirmar eliminación</h5>
+            <button type="button" class="btn-close" aria-label="Close" (click)="closeDeleteModal()">
+              <span aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>¿Desea eliminar el atributo seleccionado?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-danger" (click)="performDelete()">Eliminar</button>
+            <button type="button" class="btn btn-success" (click)="closeDeleteModal()">Cancelar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-backdrop fade show" *ngIf="deleteId !== null"></div>
+  `,
+  styles: []
+})
+export class CatalogoAtributoListComponent implements OnInit {
+  atributos: CatalogoAtributo[] = [];
+  deleteId: number | null = null;
+
+  constructor(
+    private service: CatalogoAtributoService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    this.loadAtributos();
+  }
+
+  loadAtributos(): void {
+    this.service.getCatalogoAtributos().subscribe((data) => (this.atributos = data));
+  }
+
+  editAtributo(id: number): void {
+    this.router.navigate([id], { relativeTo: this.route });
+  }
+
+  confirmDelete(id: number): void {
+    this.deleteId = id;
+  }
+
+  closeDeleteModal(): void {
+    this.deleteId = null;
+  }
+
+  performDelete(): void {
+    if (this.deleteId === null) return;
+    this.service.deleteCatalogoAtributo(this.deleteId).subscribe({
+      next: () => {
+        this.deleteId = null;
+        this.loadAtributos();
+      }
+    });
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,8 @@ import { CategoriaFormComponent } from './admin/categoria-form.component';
 import { AdminHomeComponent } from './admin/admin-home.component';
 import { ProductoListComponent } from './admin/producto-list.component';
 import { ProductoFormComponent } from './admin/producto-form.component';
+import { CatalogoAtributoListComponent } from './admin/catalogo-atributo-list.component';
+import { CatalogoAtributoFormComponent } from './admin/catalogo-atributo-form.component';
 
 export const appRoutes: Routes = [
   { path: '', component: CatalogComponent },
@@ -19,7 +21,10 @@ export const appRoutes: Routes = [
       { path: 'categoria/:id', component: CategoriaFormComponent },
       { path: 'producto', component: ProductoListComponent },
       { path: 'producto/nuevo', component: ProductoFormComponent },
-      { path: 'producto/:id', component: ProductoFormComponent }
+      { path: 'producto/:id', component: ProductoFormComponent },
+      { path: 'catalogo-atributo', component: CatalogoAtributoListComponent },
+      { path: 'catalogo-atributo/nuevo', component: CatalogoAtributoFormComponent },
+      { path: 'catalogo-atributo/:id', component: CatalogoAtributoFormComponent }
     ]
   }
 ];

--- a/src/app/models/catalogo-atributo.model.ts
+++ b/src/app/models/catalogo-atributo.model.ts
@@ -1,0 +1,25 @@
+export type DataType = 'TEXT' | 'NUMERIC' | 'BOOLEAN' | 'DATE';
+
+export interface CatalogoAtributo {
+  id: number;
+  nombre: string;
+  dataType: DataType;
+  unidad?: string;
+  descripcion?: string;
+  orden?: number;
+  valorMin?: number;
+  valorMax?: number;
+  activo: boolean;
+}
+
+export interface CatalogoAtributoRequest {
+  nombre: string;
+  dataType: DataType;
+  unidad?: string;
+  descripcion?: string;
+  orden?: number;
+  valorMin?: number;
+  valorMax?: number;
+  activo: boolean;
+  validRange?: boolean;
+}

--- a/src/app/services/catalogo-atributo.service.ts
+++ b/src/app/services/catalogo-atributo.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { CatalogoAtributo, CatalogoAtributoRequest } from '../models/catalogo-atributo.model';
+
+@Injectable({ providedIn: 'root' })
+export class CatalogoAtributoService {
+  private baseUrl = environment.apiBaseUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getCatalogoAtributos(): Observable<CatalogoAtributo[]> {
+    return this.http
+      .get<{ data: CatalogoAtributo[] }>(`${this.baseUrl}/catalogo-atributos`)
+      .pipe(map((resp) => resp.data));
+  }
+
+  getCatalogoAtributo(id: number): Observable<CatalogoAtributo> {
+    return this.http
+      .get<{ data: CatalogoAtributo }>(`${this.baseUrl}/catalogo-atributos/${id}`)
+      .pipe(map((resp) => resp.data));
+  }
+
+  createCatalogoAtributo(req: CatalogoAtributoRequest): Observable<CatalogoAtributo> {
+    return this.http
+      .post<{ data: CatalogoAtributo }>(`${this.baseUrl}/catalogo-atributos`, req)
+      .pipe(map((resp) => resp.data));
+  }
+
+  updateCatalogoAtributo(id: number, req: CatalogoAtributoRequest): Observable<CatalogoAtributo> {
+    return this.http
+      .put<{ data: CatalogoAtributo }>(`${this.baseUrl}/catalogo-atributos/${id}`, req)
+      .pipe(map((resp) => resp.data));
+  }
+
+  deleteCatalogoAtributo(id: number): Observable<void> {
+    return this.http
+      .delete<{ data: void }>(`${this.baseUrl}/catalogo-atributos/${id}`)
+      .pipe(map(() => undefined));
+  }
+}


### PR DESCRIPTION
## Summary
- add models and service for `CatalogoAtributo`
- implement admin list and form components for catalog attributes
- wire new components into admin navigation and routing

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a72e320c832fa0474a7a802e8ea1